### PR TITLE
Remove bundler-cache from Ruby setup in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
-          bundler-cache: true
           ruby-version: ruby
 
       # Release


### PR DESCRIPTION
Allegedly safer according to zizmor