### PR TITLE
Add concurrency protection for the build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ on:
 
 jobs:
   build:
+    concurrency:
+      group: build-${{ github.head_ref || github.run_id }}-ruby-${{matrix.ruby }}-rails-${{ matrix.rails }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }}
     strategy:


### PR DESCRIPTION
This cancels in-progress concurrent test runs because the test runs take so dang long.